### PR TITLE
Fix bug with FindClass

### DIFF
--- a/Add-To-Your-Own-Project/AnalyticXStringUtilAndroid.cpp
+++ b/Add-To-Your-Own-Project/AnalyticXStringUtilAndroid.cpp
@@ -22,7 +22,7 @@ jobjectArray AnalyticXStringUtilAndroid::jobjectArrayFromCCDictionary(cocos2d::J
     JNIEnv *pEnv = minfo.env;
     jclass jStringCls = 0;
         
-    jStringCls = pEnv->FindClass("[Ljava/lang/String;");
+    jStringCls = pEnv->FindClass("java/lang/String");
         
     jobjectArray result;
         

--- a/AnalyticX/Classes/AnalyticXStringUtilAndroid.cpp
+++ b/AnalyticX/Classes/AnalyticXStringUtilAndroid.cpp
@@ -21,7 +21,7 @@ jobjectArray AnalyticXStringUtilAndroid::jobjectArrayFromCCDictionary(cocos2d::J
     JNIEnv *pEnv = minfo.env;
     jclass jStringCls = 0;
         
-    jStringCls = pEnv->FindClass("[Ljava/lang/String;");
+    jStringCls = pEnv->FindClass("java/lang/String");
         
     jobjectArray result;
         


### PR DESCRIPTION
On some newer devices, FindClass("[Ljava/lang/String:"); crash the whole app. Instead, FindClass("java/lang/String"); works properly.
